### PR TITLE
ignore venv in python examples

### DIFF
--- a/sentiment/.gitignore
+++ b/sentiment/.gitignore
@@ -2,3 +2,8 @@ tmp/**
 start_time
 out.json
 huggingface
+bin
+lib
+lib64
+share
+pyvenv.cfg

--- a/textgen-gpt2/.gitignore
+++ b/textgen-gpt2/.gitignore
@@ -2,3 +2,8 @@ tmp/**
 start_time
 out.json
 huggingface
+bin
+lib
+lib64
+share
+pyvenv.cfg


### PR DESCRIPTION
venv makes it easy to play with these examples straight n the host machine. This makes git ignore venv files